### PR TITLE
Fix causes of compilation errors in .ini and marlin.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,5 @@ __pycache__
 # Simulation / Native
 eeprom.dat
 imgui.ini
+build_output*.log
+compile_commands.json

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,6 +23,7 @@ extra_configs =
     ini/lpc176x.ini
     ini/native.ini
     ini/samd51.ini
+    ini/stm32-common.ini
     ini/stm32f0.ini
     ini/stm32f1.ini
     ini/stm32f4.ini


### PR DESCRIPTION
### Description

Adds/restores missing     "ini/stm32-common.ini"   to platformio.ini, in [platformio], "extra configs =" section
Updates .gitignore to disregard some troubleshooting log files on my local system

### Requirements

no

### Benefits

fixes minor compilation error

